### PR TITLE
Uses HTTPS address instead of SSH for vamp submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "lib/qm-vamp-plugins"]
 	path = lib/qm-vamp-plugins
-	url = git@github.com:philippReist/qm-vamp-plugins.git
+	url = https://github.com/philippReist/qm-vamp-plugins.git
 [submodule "lib/libsndfile"]
 	path = lib/libsndfile
 	url = https://github.com/erikd/libsndfile.git


### PR DESCRIPTION
The vamp module was using the SSH address, making it impossible for me to download (unless you gave me SSH access). So I changed it to the HTTPS address, which is public.