### PR TITLE
Automatically Adds Release Assets

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
       - develop
+  release:
+    types:
+      - published
 
 jobs:
   build:
@@ -36,6 +39,25 @@ jobs:
         cmake -DCMAKE_PREFIX_PATH="${Qt5_Dir}" -DCMAKE_BUILD_TYPE=Release ../
         make -j
 
-    - name: Run Tests
+    - name: Unit Tests
       run: |
         sh scripts/run_tests.sh build
+
+    - name: Deploy
+      run: |
+        cd gui/mac_os_rc/
+        sh deploy.sh ../../build/ "${Qt5_Dir}/bin/" ../ 
+        mv build/Dancebots\ Editor.dmg build/dancebots_editor-darwin.dmg
+
+    - name: Upload Release Asset
+      id: upload-release-asset 
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets{?name,label}"
+        asset_path: build/dancebots_editor-darwin.dmg
+        asset_name: dancebots_editor-darwin.dmg
+        asset_content_type: application/x-apple-diskimage
+

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -21,13 +21,13 @@ jobs:
 
     steps:
     - name: Install Qt ${{ matrix.qt_version }}
-      uses: jurplel/install-qt-action@v2.2.1
+      uses: jurplel/install-qt-action@v2.3.0
       with:
         version: ${{ matrix.qt_version }}
         target: desktop
 
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Update git submodules
       run: |

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         cd gui/mac_os_rc/
         sh deploy.sh ../../build/ "${Qt5_Dir}/bin/" ../ 
-        mv build/Dancebots\ Editor.dmg build/dancebots_editor-darwin.dmg
+        mv ../../build/Dancebots\ Editor.dmg ../../build/dancebots_editor-darwin.dmg
 
     - name: Upload Release Asset
       id: upload-release-asset 

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -1,7 +1,7 @@
 name: macOS Build
 
 on:
-  push:
+  pull_request:
     branches:
       - master
       - develop

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -8,6 +8,7 @@ on:
   release:
     types:
       - published
+      - prereleased
 
 jobs:
   build:
@@ -47,7 +48,7 @@ jobs:
       run: |
         cd gui/mac_os_rc/
         sh deploy.sh ../../build/ "${Qt5_Dir}/bin/" ../ 
-        mv ../../build/Dancebots\ Editor.dmg ../../build/dancebots_editor-darwin.dmg
+        mv ../../build/Dancebots\ Editor.dmg ../../build/dancebots-editor-darwin.dmg
 
     - name: Upload Release Asset
       id: upload-release-asset 
@@ -57,7 +58,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets{?name,label}"
-        asset_path: build/dancebots_editor-darwin.dmg
-        asset_name: dancebots_editor-darwin.dmg
+        asset_path: build/dancebots-editor-darwin.dmg
+        asset_name: dancebots-editor-darwin.dmg
         asset_content_type: application/x-apple-diskimage
 

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -26,13 +26,13 @@ jobs:
         sudo apt-get install build-essential libpulse-dev libgl1-mesa-dev
 
     - name: Install Qt ${{ matrix.qt_version }}
-      uses: jurplel/install-qt-action@v2.2.1
+      uses: jurplel/install-qt-action@v2.3.0
       with:
         version: ${{ matrix.qt_version }}
         target: desktop
 
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     
     - name: Update git submodules
       run: |

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -1,7 +1,7 @@
 name: Ubuntu Build
 
 on:
-  push:
+  pull_request:
     branches:
       - master
       - develop

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
       - develop
+  release:
+    types:
+      - published
 
 jobs:
   build:
@@ -46,6 +49,24 @@ jobs:
         ../cmake-3.16.2-Linux-x86_64/bin/cmake -DCMAKE_PREFIX_PATH=${Qt5_Dir} -DCMAKE_BUILD_TYPE=Release ../
         make -j
 
-    - name: Run Tests
+    - name: Unit Tests
       run: |
         sh scripts/run_tests.sh build
+
+    - name: Deploy
+      run: |
+        mv build/gui/dancebotGui ../dancebots_editor
+        tar -zcvf build/dancebots_editor-ubuntu.tar.gz build/dancebots_editor 
+
+    - name: Upload Release Asset
+      id: upload-release-asset 
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets{?name,label}"
+        asset_path: build/dancebots_editor-ubuntu.tar.gz
+        asset_name: dancebots_editor-ubuntu.tar.gz
+        asset_content_type: application/zip
+

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -8,6 +8,7 @@ on:
   release:
     types:
       - published
+      - prereleased
 
 jobs:
   build:
@@ -56,8 +57,8 @@ jobs:
     - name: Deploy
       run: |
         cd build/
-        mv gui/dancebotsEditor dancebots_editor
-        tar -zcvf dancebots_editor-ubuntu.tar.gz dancebots_editor 
+        mv gui/dancebotsEditor dancebots-editor
+        tar -zcvf dancebots-editor-ubuntu.tar.gz dancebots-editor 
 
     - name: Upload Release Asset
       id: upload-release-asset 
@@ -67,7 +68,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets{?name,label}"
-        asset_path: build/dancebots_editor-ubuntu.tar.gz
-        asset_name: dancebots_editor-ubuntu.tar.gz
+        asset_path: build/dancebots-editor-ubuntu.tar.gz
+        asset_name: dancebots-editor-ubuntu.tar.gz
         asset_content_type: application/zip
 

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -55,8 +55,9 @@ jobs:
 
     - name: Deploy
       run: |
-        mv build/gui/dancebotGui ../dancebots_editor
-        tar -zcvf build/dancebots_editor-ubuntu.tar.gz build/dancebots_editor 
+        cd build/
+        mv gui/dancebotsEditor dancebots_editor
+        tar -zcvf dancebots_editor-ubuntu.tar.gz dancebots_editor 
 
     - name: Upload Release Asset
       id: upload-release-asset 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The script will create `Dancebots Editor.app` and `Dancebots Editor.dmg` in your
    sudo apt-get install cmake
    ```
 
-3. Install Qt 5.12.6 LTS (gcc 64-bit). The easiest is to use the [online installer](https://www.qt.io/download). Take note of the installation directory as you will need it in the Build step.
+3. Install the Qt 5.12.6 LTS Desktop gcc 64-bit component. The easiest is to use the [online installer](https://www.qt.io/download). Take note of the installation directory as you will need it in the Build step.
 
 3. Clone the repository and update submodules:
    ```


### PR DESCRIPTION
After this PR is merged into master (or develop): 
The next time you [create a release](https://github.com/philippReist/dancebots_gui/releases/new), the build system will automatically add the Linux and macOS release assets to the release, see photo.
![Screenshot from 2020-02-06 14-55-00](https://user-images.githubusercontent.com/44389573/73909702-b0930f00-48f0-11ea-8f93-ef49b28d963f.png)

This should work for both published and pre-releases.